### PR TITLE
fix(retrieval): close citation-grounding gap and honor SCHOLAR_RAG_MAX_HOPS

### DIFF
--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -49,7 +49,7 @@ class AppContainer:
         )
         executor = Executor(
             retriever=self.hybrid_retriever,
-            multihop_retriever=MultiHopRetriever(self.graph_store),
+            multihop_retriever=MultiHopRetriever(self.graph_store, max_depth=settings.max_hops),
             reranker=AdaptiveReranker(),
             llm=self.llm,
             grounder=CitationGrounder(),

--- a/src/retrieval/citations.py
+++ b/src/retrieval/citations.py
@@ -22,7 +22,7 @@ class CitationGrounder:
             for chunk_id in supporting_ids:
                 chunk = chunk_by_id[chunk_id]
                 chunk_terms = set(tokenize(chunk.text))
-                if not claim_terms or claim_terms & chunk_terms:
+                if claim_terms and claim_terms & chunk_terms:
                     grounded_ids.append(chunk_id)
                     citations[chunk_id] = Citation(
                         chunk_id=chunk.chunk_id,

--- a/tests/test_citations.py
+++ b/tests/test_citations.py
@@ -21,3 +21,22 @@ def test_grounder_flags_unsupported_claims() -> None:
     )
     assert answer.ungrounded is True
     assert answer.answer.startswith("[UNGROUNDED]")
+
+
+def test_grounder_flags_empty_token_claim_as_ungrounded() -> None:
+    """A claim that tokenizes to nothing must not be auto-grounded by an attached chunk id."""
+    chunk = Chunk(
+        chunk_id="c1",
+        document_id="d1",
+        title="Evidence",
+        text="Hybrid retrieval improves grounded scientific answers.",
+        source="fixture",
+    )
+    answer = CitationGrounder().ground(
+        answer_text="   ",
+        claims=[Claim(text="   ", chunk_ids=["c1"])],
+        retrieved_chunks=[chunk],
+    )
+    assert answer.ungrounded is True
+    assert answer.answer.startswith("[UNGROUNDED]")
+    assert answer.citations == []

--- a/tests/test_graph_multihop.py
+++ b/tests/test_graph_multihop.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 
 from retrieval.graph import GraphRAGBuilder
-from retrieval.models import Chunk
+from retrieval.models import Chunk, Entity, EntityEdge
 from retrieval.multihop import MultiHopRetriever
 from storage.graph_store import SQLiteGraphStore
 
@@ -30,3 +30,25 @@ async def test_multihop_retriever_follows_entity_chain(tmp_path: Path) -> None:
     GraphRAGBuilder(store).index_chunks(chunks)
     results = await MultiHopRetriever(store).retrieve("GraphRAG", ["GraphRAG"], depth=3, limit=5)
     assert {result.chunk.chunk_id for result in results}
+
+
+async def test_multihop_max_depth_bounds_traversal(tmp_path: Path) -> None:
+    """``max_depth`` must bound traversal so the configured hop cap is enforced.
+
+    This is the cap wired from ``settings.max_hops`` in the API container.
+    A second-hop chunk should only be reachable when ``max_depth`` allows it.
+    """
+    store = SQLiteGraphStore(tmp_path / "graph.sqlite3")
+    chunk_a = Chunk(chunk_id="a", document_id="d", title="A", text="Alpha", source="fixture")
+    chunk_b = Chunk(chunk_id="b", document_id="d", title="B", text="Beta", source="fixture")
+    store.add_mentions(chunk_a, [Entity(name="Alpha", label="TERM")])
+    store.add_mentions(chunk_b, [Entity(name="Beta", label="TERM")])
+    store.add_edges([EntityEdge(source="Alpha", target="Beta", chunk_id="a")])
+
+    shallow = await MultiHopRetriever(store, max_depth=1).retrieve(
+        "q", ["Alpha"], depth=5, limit=10
+    )
+    deep = await MultiHopRetriever(store, max_depth=3).retrieve("q", ["Alpha"], depth=5, limit=10)
+
+    assert {result.chunk.chunk_id for result in shallow} == {"a"}
+    assert {result.chunk.chunk_id for result in deep} == {"a", "b"}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two correctness fixes found during the daily audit, both deterministic and offline (no `all` extra, no network).

### 1. Citation grounder: empty-token claims bypassed the lexical check (safety)
`CitationGrounder.ground()` used `if not claim_terms or claim_terms & chunk_terms:`. A claim whose text tokenizes to nothing (whitespace/punctuation-only) made `not claim_terms` true, so it was marked **grounded** for any attached `chunk_id` regardless of overlap — weakening the documented `[UNGROUNDED]` hallucination guard. Changed to `if claim_terms and claim_terms & chunk_terms:` so empty-token claims (and claims with no overlap) stay ungrounded.

### 2. `SCHOLAR_RAG_MAX_HOPS` was documented but never applied
`AppContainer` built `MultiHopRetriever(self.graph_store)`, which uses the hardcoded default `max_depth=3`, so `settings.max_hops` (and the `SCHOLAR_RAG_MAX_HOPS` env var documented in `CONFIGURATION.md`/`SAFETY.md`) had no effect on graph traversal. Wired `max_depth=settings.max_hops` into the retriever.

**No default behavior change:** the default `max_hops` is 5 and planner retrieval tasks already cap at ≤3 hops, so traversal at defaults is identical. The fix only matters when an operator *lowers* `SCHOLAR_RAG_MAX_HOPS`, which is now correctly enforced.

## Changes
- `src/retrieval/citations.py`: require non-empty lexical overlap for grounding.
- `src/api/dependencies.py`: pass `max_depth=settings.max_hops` into `MultiHopRetriever`.
- `tests/test_citations.py`: whitespace-only claim is flagged ungrounded with no citations (fails before the fix).
- `tests/test_graph_multihop.py`: `max_depth` bounds traversal — a second-hop chunk is reachable at `max_depth=3` but not `max_depth=1` (locks the mechanism the wiring relies on).

## Validation
In the repo `.venv` (Python 3.12, `uv sync --extra dev`):
- `ruff check .` — passed
- `ruff format --check .` — 63 files formatted
- `mypy src/agent --ignore-missing-imports` — success
- `pytest tests/ -q` — 23 passed (+2 new tests)

Confirmed the grounding regression test fails on `main` before the fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

